### PR TITLE
Add alternate deps install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,14 @@ These dependencies must be present before building:
  - `libwnck-3-dev`
 
 
-Use the following command to install the dependencies:
+Use the following command to install the dependencies on Elementary:
 ```shell
 sudo apt install elementary-sdk libgtop2-dev libwnck-3-dev
+```
+ 
+Use the following command to install the dependencies on other Debian-based systems:
+```shell
+apt install meson valac appstream-util cmake libgranite-dev libgtop2-dev libwnck-3-dev
 ```
  
 ### Building


### PR DESCRIPTION
Added instructions for installing the specific dependencies on non-Elementary Debian-based systems. The build process, and the app itself, is confirmed to work with these dependencies on Pop!_OS.